### PR TITLE
make resquest processor return a result instead of a bool

### DIFF
--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -3,7 +3,7 @@ use super::lcn_config;
 use super::requests::*;
 use super::systems;
 
-pub fn run(rx: std::sync::mpsc::Receiver<Request>) {
+pub fn run(rx: std::sync::mpsc::Receiver<Request>) -> Result<(), String> {
     let mut world = lame_ecs::create_world!();
     let client = reqwest::blocking::Client::builder()
         .timeout(std::time::Duration::from_secs(1))
@@ -13,9 +13,7 @@ pub fn run(rx: std::sync::mpsc::Receiver<Request>) {
 
     loop {
         std::thread::sleep(std::time::Duration::from_secs(1));
-        if !systems::request_processor::process(&mut world, &rx) {
-            break;
-        }
+        systems::request_processor::process(&mut world, &rx)?;
         systems::scheduler::process(&mut world);
         systems::lcn_command_executor::process(&mut world, &lcn_config, &client);
     }

--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -2,7 +2,7 @@ use super::components::*;
 use super::lcn_config;
 use super::requests::*;
 use super::systems;
-use rocket::tokio::sync::mpsc::UnboundedReceiver;
+use rocket::tokio::{runtime::Runtime, sync::mpsc::UnboundedReceiver};
 
 pub fn run(mut rx: UnboundedReceiver<Request>) -> Result<(), String> {
     let mut world = lame_ecs::create_world!();
@@ -11,10 +11,9 @@ pub fn run(mut rx: UnboundedReceiver<Request>) -> Result<(), String> {
         .build()
         .expect("could not init http client");
     let lcn_config = lcn_config::from_file("lcn_config.json").expect("could not parse config file");
-
+    let runtime = Runtime::new().expect("could not create tokio runtime");
     loop {
-        std::thread::sleep(std::time::Duration::from_secs(1));
-        systems::request_processor::process(&mut world, &mut rx)?;
+        runtime.block_on(systems::request_processor::process(&mut world, &mut rx))?;
         systems::scheduler::process(&mut world);
         systems::lcn_command_executor::process(&mut world, &lcn_config, &client);
     }

--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -2,8 +2,9 @@ use super::components::*;
 use super::lcn_config;
 use super::requests::*;
 use super::systems;
+use rocket::tokio::sync::mpsc::UnboundedReceiver;
 
-pub fn run(rx: std::sync::mpsc::Receiver<Request>) -> Result<(), String> {
+pub fn run(mut rx: UnboundedReceiver<Request>) -> Result<(), String> {
     let mut world = lame_ecs::create_world!();
     let client = reqwest::blocking::Client::builder()
         .timeout(std::time::Duration::from_secs(1))
@@ -13,7 +14,7 @@ pub fn run(rx: std::sync::mpsc::Receiver<Request>) -> Result<(), String> {
 
     loop {
         std::thread::sleep(std::time::Duration::from_secs(1));
-        systems::request_processor::process(&mut world, &rx)?;
+        systems::request_processor::process(&mut world, &mut rx)?;
         systems::scheduler::process(&mut world);
         systems::lcn_command_executor::process(&mut world, &lcn_config, &client);
     }

--- a/src/systems/request_processor.rs
+++ b/src/systems/request_processor.rs
@@ -3,15 +3,15 @@ use super::super::requests::*;
 use lame_ecs::{Entity, World};
 use std::sync::mpsc;
 
-pub fn process(world: &mut World, rx: &mpsc::Receiver<Request>) -> bool {
+pub fn process(world: &mut World, rx: &mpsc::Receiver<Request>) -> Result<(), String> {
     let input = rx.try_recv();
     let request = match input {
         Ok(request) => request,
         Err(mpsc::TryRecvError::Empty) => {
-            return true;
+            return Ok(());
         }
         Err(mpsc::TryRecvError::Disconnected) => {
-            return false;
+            return Err("Producer thread diconnected".to_owned());
         }
     };
     match request {
@@ -32,7 +32,7 @@ pub fn process(world: &mut World, rx: &mpsc::Receiver<Request>) -> bool {
             send_response(tx, Response::GetStatus(status), "GetStatus");
         }
     }
-    true
+    Ok(())
 }
 
 fn send_response(tx: mpsc::SyncSender<Response>, response: Response, tag: &str) {

--- a/src/systems/request_processor.rs
+++ b/src/systems/request_processor.rs
@@ -1,19 +1,29 @@
 use super::super::components::*;
 use super::super::requests::*;
 use lame_ecs::{Entity, World};
-use rocket::tokio::sync::mpsc::{error::TryRecvError, UnboundedReceiver};
+use rocket::tokio::sync::mpsc::UnboundedReceiver;
 use rocket::tokio::sync::oneshot::Sender;
+use rocket::tokio::time::timeout;
 
-pub fn process(world: &mut World, rx: &mut UnboundedReceiver<Request>) -> Result<(), String> {
-    let input = rx.try_recv();
+pub async fn process(world: &mut World, rx: &mut UnboundedReceiver<Request>) -> Result<(), String> {
+    let seconds_to_next_task = get_seconds_to_next_execution(world);
+    let input = match seconds_to_next_task {
+        Some(s) => {
+            println!("request_processor: blocking for {} seconds", s);
+            let r = timeout(std::time::Duration::from_secs(s), rx.recv()).await;
+            if r.is_err() {
+                return Ok(());
+            }
+            r.unwrap()
+        }
+        None => {
+            println!("request_processor: blocking indefinitely");
+            rx.recv().await
+        }
+    };
     let request = match input {
-        Ok(request) => request,
-        Err(TryRecvError::Empty) => {
-            return Ok(());
-        }
-        Err(TryRecvError::Disconnected) => {
-            return Err("Producer thread diconnected".to_owned());
-        }
+        Some(r) => r,
+        None => return Err("Producer thread diconnected".to_owned()),
     };
     match request {
         Request::NewTask(data) => {
@@ -48,4 +58,21 @@ fn create_lcn_task(world: &mut World, task: TaskRequest) -> Entity {
     world.add_component(entity, ActivationState::ToBeScheduled);
     world.add_component(entity, task.cmd);
     entity
+}
+
+fn get_seconds_to_next_execution(world: &World) -> Option<u64> {
+    let mut time: Option<i64> = None;
+    let now = chrono::Local::now().timestamp();
+    for (state, _) in lame_ecs::component_iter!(world, ActivationState) {
+        match state {
+            ActivationState::Scheduled(t) if t < &time.unwrap_or(i64::MAX) => time = Some(*t),
+            ActivationState::ReadyToRun => return Some(0),
+            _ => {}
+        }
+    }
+    let seconds = time? - now;
+    if seconds < 0 {
+        panic!("task should be executed in the past but is not ready to run");
+    }
+    Some(seconds as u64)
 }


### PR DESCRIPTION
The main goal of this pr is to make the event_loop thread block until a task needs to be executed or until a new command is received. If there is not task to be executed it the event_loop will be blocked indefinitely until a new command arrives.